### PR TITLE
Fixed behaviour of property injection for private properties in class hierarchies

### DIFF
--- a/spec/watoki/factory/FactoryFixture.php
+++ b/spec/watoki/factory/FactoryFixture.php
@@ -122,9 +122,7 @@ class FactoryFixture extends Fixture {
     }
 
     public function theTheProperty_ShouldBeAnInstanceOf($propertyName, $class) {
-        $reflection = new \ReflectionProperty(get_class($this->instance), $propertyName);
-        $reflection->setAccessible(true);
-        $this->spec->assertInstanceOf($class, $reflection->getValue($this->instance));
+        $this->spec->assertInstanceOf($class, $this->getPropertyValue($propertyName));
     }
 
     public function thenTheShouldBeNoProperty($propertyName) {
@@ -141,6 +139,19 @@ class FactoryFixture extends Fixture {
 
     public function thenTheTheProperty_OfTheObjectShouldBeTheFactory($prop) {
         $this->spec->assertTrue($this->factory === $this->instance->$prop);
+    }
+
+    private function getPropertyValue($propertyName) {
+        $classReflection = new \ReflectionClass($this->instance);
+        while ($classReflection) {
+            if ($classReflection->hasProperty($propertyName)) {
+                $property = $classReflection->getProperty($propertyName);
+                $property->setAccessible(true);
+                return $property->getValue($this->instance);
+            };
+            $classReflection = $classReflection->getParentClass();
+        }
+        return null;
     }
 
 }

--- a/spec/watoki/factory/PropertyInjectionTest.php
+++ b/spec/watoki/factory/PropertyInjectionTest.php
@@ -15,6 +15,21 @@ class PropertyInjectionTest extends Specification {
                 /**
                  * @var StdClass <-
                  */
+                public $foo;
+            }
+        ');
+
+        $this->fix->whenIGet_FromTheFactory('PublicProperty');
+
+        $this->fix->theTheProperty_ShouldBeAnInstanceOf('foo', 'StdClass');
+    }
+
+    public function testProtectedAndPrivateProperties() {
+        $this->fix->givenTheClassDefinition('
+            class ProtectedAndPrivateProperty {
+                /**
+                 * @var StdClass <-
+                 */
                 protected $foo;
 
                 /**
@@ -24,25 +39,30 @@ class PropertyInjectionTest extends Specification {
             }
         ');
 
-        $this->fix->whenIGet_FromTheFactory('PublicProperty');
+        $this->fix->whenIGet_FromTheFactory('ProtectedAndPrivateProperty');
 
         $this->fix->theTheProperty_ShouldBeAnInstanceOf('foo', 'StdClass');
         $this->fix->theTheProperty_ShouldBeAnInstanceOf('bar', 'StdClass');
     }
 
-    public function testProtectedAndPrivateProperties() {
+    public function testInjectPrivatePropertyFromBaseClass() {
         $this->fix->givenTheClassDefinition('
-            class ProtectedAndPrivateProperty {
+            class PrivatePropertyBase {
                 /**
                  * @var StdClass <-
                  */
-                public $foo;
+                private $foo;
             }
         ');
 
-        $this->fix->whenIGet_FromTheFactory('ProtectedAndPrivateProperty');
+        $this->fix->givenTheClassDefinition('
+            class InheritsPrivateProperty extends PrivatePropertyBase {
 
-        $this->fix->theTheProperty_ShouldBeAnInstanceOf('foo', 'StdClass');
+            }
+        ');
+
+        $this->fix->whenIGet_FromTheFactory('InheritsPrivateProperty');
+
         $this->fix->theTheProperty_ShouldBeAnInstanceOf('foo', 'StdClass');
     }
 


### PR DESCRIPTION
It was not possible to use property injection for private fields in class hierarchies (not sure about protected maybe the same issue appeared there as well, the issue https://github.com/watoki/factory/issues/1 references this behaviour).

I only added a test for private fields since the problem appeared to me in this context. We might want to change the test (or add an additional one) to prove that property injection works as well for protected and public fields if they were inherited.
