### PR TITLE
HHVM compatibility

### DIFF
--- a/src/watoki/factory/Factory.php
+++ b/src/watoki/factory/Factory.php
@@ -70,6 +70,11 @@ class Factory {
     }
 
     private function findMatchingProvider($class) {
+        $isHHVM = defined('HHVM_VERSION');
+
+        // fix for a hhvm issue, see https://github.com/facebook/hhvm/issues/2097
+        $parentClasses = $isHHVM ? class_parents($class) : [];
+
         while ($class) {
             $normalized = $this->normalizeClass($class);
             foreach ($this->providers as $key => $provider) {
@@ -77,7 +82,7 @@ class Factory {
                     return $provider;
                 }
             }
-            $class = get_parent_class($class);
+            $class = $isHHVM ? array_shift($parentClasses) : get_parent_class($class);
         }
         return $this->providers['stdclass'];
     }


### PR DESCRIPTION
Unfortunately due the issue https://github.com/facebook/hhvm/issues/2097 the project cannot be used with hhvm.

This PR applies a quite simple fix which allows compatibility to the current hhvm version.

See also https://gist.github.com/jwoschitz/bba710a35418e701636d

There is no test case at the moment but the problem appeared while testing hhvm compat of https://github.com/rtens/Mockster. With the problem at hand Mockster cannot be used with hhvm.
